### PR TITLE
[FIX] Use urllib's quote for URL parameter encoding in FileAdapter

### DIFF
--- a/src/file_manager_client/adapter/file_adapter.py
+++ b/src/file_manager_client/adapter/file_adapter.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, List, Union
-from pathlib import Path
+from urllib.parse import quote
 from .exceptions import FileManagerAdapterException
 from ..utils.http_client import HttpClient
 from ..models.response import FileResponse
@@ -110,10 +110,10 @@ class FileAdapter:
             if is_iterable:
                 for item in value:
                     if item:
-                        query_parts.append(f"{key}={item}")
+                        query_parts.append(f"{key}={quote(str(item), safe='/')}")
             elif value:
-                query_parts.append(f"{key}={value}")
-
+                query_parts.append(f"{key}={quote(str(value), safe='/')}")
+                
         if not query_parts:
             return base_url
 


### PR DESCRIPTION
## 1. Summary
This PR updates the file manager client to ensure all query parameter values are properly URL-encoded using `urllib.parse.quote`, improving support for special characters in file and folder names.

## 2. Description
The FileAdapter is a Python client for interacting with the file manager service via HTTP. This change ensures that all query parameters (such as file paths, folder names, and extensions) are encoded safely when constructing URLs, preventing issues with special characters (e.g., spaces, `+`, `%`, `@`). This makes the client more robust and compatible with the server's expectations for URL-encoded input.

## 3. Features
- URL-encodes all query parameter values using `quote`.
- Supports special characters in file and folder names.
- Prevents errors caused by malformed or unencoded URLs.

## 4. Related Issue
Related to: [CHATO-305](https://thubantech-team.atlassian.net/browse/CHATO-305)

## 5. Implementation Details

### Endpoints
- The client interacts with all file manager endpoints that require query parameters, such as file upload, download, update, delete, and structure retrieval.

### Components
- **FileAdapter**: Main client class responsible for building URLs and making HTTP requests.
- **quote**: Used from `urllib.parse` to encode query parameter values.

## 6. Technology Stack
- Python 3.x
- `requests` (HTTP client)
- `urllib.parse.quote` for URL encoding